### PR TITLE
fix: replace deprecated github actions

### DIFF
--- a/.github/workflows/mysql-migrations.yml
+++ b/.github/workflows/mysql-migrations.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache-dir
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
       id: cache-dependencies
       uses: actions/cache@v2


### PR DESCRIPTION
## Description
- `set-output` has been deprecated by GitHub and it is suggested to be replaced by GitHub.