### PR TITLE
Upgrade from Python 3.8 to Python 3.11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.11"]
         os: [ubuntu-20.04]
         toxenv: [django42]
         node: [16]

--- a/.github/workflows/mysql-migrations.yml
+++ b/.github/workflows/mysql-migrations.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ 3.11 ]
 
     steps:
     - name: Checkout repo

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
    os: "ubuntu-20.04"
    tools:
-      python: "3.8"
+      python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install --no-install-recommends -qy \
   language-pack-en \
   build-essential \
-  python3.8-dev \
+  python3.11-dev \
   python3-virtualenv \
-  python3.8-distutils \
+  python3.11-distutils \
   libmysqlclient-dev \
   pkg-config \
   libssl-dev \
@@ -44,7 +44,7 @@ ENV INSIGHTS_APP_DIR ${INSIGHTS_APP_DIR}
 ENV THEME_SCSS "sass/themes/open-edx.scss"
 
 # No need to activate insights virtualenv as it is already activated by putting in the path
-RUN virtualenv -p python3.8 --always-copy ${INSIGHTS_VENV_DIR}
+RUN virtualenv -p python3.11 --always-copy ${INSIGHTS_VENV_DIR}
 
 COPY requirements ${INSIGHTS_CODE_DIR}/requirements
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The following sections are for historical purposes only.
 
 Prerequisites
 -------------
-* Python 3.8.x
+* Python 3.11.x
 * [gettext](http://www.gnu.org/software/gettext/)
 * [node](https://nodejs.org) 12.11.1
 * [npm](https://www.npmjs.org/) 6.11.3

--- a/docs/en_us/dashboard/source/conf.py
+++ b/docs/en_us/dashboard/source/conf.py
@@ -14,6 +14,7 @@ html_logo = "https://logos.openedx.org/open-edx-logo-color.png"
 html_favicon = "https://logos.openedx.org/open-edx-favicon.ico"
 
 html_theme_options = {
+ "announcement": "edX Insights is no longer supported by the Open edX community.<br><br>See <a href='https://docs.openedx.org/projects/openedx-aspects/en/latest/index.html'>Aspects</a> for the community-supported Open edX Analytics solution.",
  "repository_url": "https://github.com/openedx/edx-analytics-dashboard",
  "repository_branch": "master",
  "path_to_docs": "docs/en_us/dashboard/source",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{42}
+envlist = py311-django{42}
 skipsdist = true
 
 [pytest]


### PR DESCRIPTION
### Description

**Jira**: None

This commits upgrades this repository to use Python 3.11 instead of Python 3.8.

This was motivated by Python 3.8's end-of-life in October of 2024 and a current incompatibility with the `importlib-resources package`.