### PR TITLE
Replace codecov with python-coverage-comment.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@ omit = analytics_dashboard/settings*
        *migrations*
        *admin.py
        *test*
+relative_files = True
 source = common, analytics_dashboard
 branch = True
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,5 +73,12 @@ jobs:
           NODE: ${{ matrix.node }}
           TOXENV: ${{ matrix.toxenv }}
           TARGETS: "requirements.js static test_python"
-      - name: code cov
-        uses: codecov/codecov-action@v3
+      - name: Run coverage
+        if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          MINIMUM_GREEN: 95
+          MINIMUM_ORANGE: 84
+          ANNOTATE_MISSING_LINES: true
+          ANNOTATION_TYPE: error


### PR DESCRIPTION
### Description

**Jira**: None

The `codecov` action no longer works because it requires a token. This replaces the use of `codecov` with [python-coverage-comment](https://github.com/marketplace/actions/python-coverage-comment), which is the tool used in other private repositories.