### PR TITLE
test: Add Node 20 to CI matrix

### DIFF
--- a/.github/scripts/testing-js.sh
+++ b/.github/scripts/testing-js.sh
@@ -1,8 +1,8 @@
-if [[ $NODE == 18 ]]
+if [[ $NODE == 20 ]]
 then
-  export NODE_VERSION=18.20.2
+    export NODE_VERSION=20.15.1
 else
-  export NODE_VERSION=16.14.0
+    export NODE_VERSION=18.20.2
 fi
 
 docker exec -t insights_testing bash -c "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ jobs:
         python-version: ["3.8", "3.12"]
         os: [ubuntu-20.04]
         toxenv: [django42]
-        node: [18]
+        node: [18, 20]
+    continue-on-error: ${{ matrix.node == 20 }}
     env:
       DATA_API_VERSION: "latest"
     steps:


### PR DESCRIPTION
Part of https://github.com/openedx/public-engineering/issues/230. 

### Description

As a first step in the upgrade to Node 20, add it to the CI matrix as a non-blocking test.

See https://github.com/openedx/public-engineering/issues/267 for the general description and motivation.