### PR TITLE
test: Remove support for Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
         python-version: ["3.8", "3.12"]
         os: [ubuntu-20.04]
         toxenv: [django42]
-        node: [18, 20]
     env:
       DATA_API_VERSION: "latest"
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,8 +63,8 @@ WORKDIR ${INSIGHTS_CODE_DIR}/
 # insights service config commands below
 RUN pip install  --no-cache-dir -r ${INSIGHTS_CODE_DIR}/requirements/production.txt 
 
-RUN nodeenv ${INSIGHTS_NODEENV_DIR} --node=18.20.2 --prebuilt \
-  && npm install -g npm@10.5.x
+RUN nodeenv ${INSIGHTS_NODEENV_DIR} --node=20.15.1 --prebuilt \
+  && npm install -g npm@10.7.x
 
 # Tried to cache the dependencies by copying related files after the npm install step but npm post install fails in that case.
 COPY . ${INSIGHTS_CODE_DIR}/


### PR DESCRIPTION
Part of https://github.com/openedx/public-engineering/issues/230. 

### Description

Completed upgrade to Node 20 by removing the Node 18 CI check and using `.nvmrc` for version to use.

See https://github.com/openedx/public-engineering/issues/267 for further information.