### PR TITLE
Remove CSRF_TRUSTED_ORIGINS_WITH_SCHEMES variable

### DIFF
--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -520,4 +520,3 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 DEFAULT_HASHING_ALGORITHM = 'sha1'
 
 CSRF_TRUSTED_ORIGINS = []
-CSRF_TRUSTED_ORIGINS_WITH_SCHEME = []  # temporary setting for Django 4.2 support

--- a/analytics_dashboard/settings/production.py
+++ b/analytics_dashboard/settings/production.py
@@ -38,6 +38,3 @@ DOCUMENTATION_LOAD_ERROR_MESSAGE = 'This data may not be available for your cour
 # Use Cloudfront CDN for assets
 if CDN_DOMAIN:
     STATIC_URL = 'https://' + CDN_DOMAIN + '/static/'
-
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME


### PR DESCRIPTION
## Description

- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/460
- Since we have upgraded to Django 4.2, we can remove the additional condition and variable.
