### PR TITLE
feat: add Datadog RUM bootstrap for Insights frontend

### DIFF
--- a/.github/workflows/mysql-migrations.yml
+++ b/.github/workflows/mysql-migrations.yml
@@ -47,6 +47,7 @@ jobs:
         mysql -V
     - name: Install Python dependencies
       run: |
+        pip install setuptools==68.2.2
         pip install -r requirements/test.txt
         pip install -r requirements/base.txt
         pip uninstall -y mysqlclient

--- a/.python-version
+++ b/.python-version
@@ -1,0 +1,1 @@
+edx-analytics-dashboard

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,0 @@
-edx-analytics-dashboard

--- a/analytics_dashboard/core/context_processors.py
+++ b/analytics_dashboard/core/context_processors.py
@@ -1,11 +1,55 @@
+import json
+
 from django.conf import settings
 
 
+def _as_bool(value):
+    if isinstance(value, str):
+        return value.strip().lower() in ('1', 'true', 'yes', 'on')
+    return bool(value)
+
+
+def _as_int(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _datadog_rum_config():
+    enabled = (
+        _as_bool(getattr(settings, 'DATADOG_RUM_ENABLED', False))
+        and bool(getattr(settings, 'DATADOG_RUM_APPLICATION_ID', None))
+        and bool(getattr(settings, 'DATADOG_RUM_CLIENT_TOKEN', None))
+    )
+
+    return {
+        'enabled': enabled,
+        'applicationId': getattr(settings, 'DATADOG_RUM_APPLICATION_ID', None),
+        'clientToken': getattr(settings, 'DATADOG_RUM_CLIENT_TOKEN', None),
+        'site': getattr(settings, 'DATADOG_RUM_SITE', 'datadoghq.com'),
+        'service': getattr(settings, 'DATADOG_RUM_SERVICE', 'edx-insights-frontend'),
+        'env': getattr(settings, 'DATADOG_RUM_ENV', None),
+        'version': getattr(settings, 'DATADOG_RUM_VERSION', '1.0.0'),
+        'scriptUrl': getattr(settings, 'DATADOG_RUM_SCRIPT_URL', None),
+        'sessionSampleRate': _as_int(getattr(settings, 'DATADOG_RUM_SESSION_SAMPLE_RATE', 20), 20),
+        'sessionReplaySampleRate': _as_int(getattr(settings, 'DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE', 0), 0),
+        'defaultPrivacyLevel': getattr(settings, 'DATADOG_RUM_DEFAULT_PRIVACY_LEVEL', 'mask'),
+        'enablePrivacyForActionName': _as_bool(
+            getattr(settings, 'DATADOG_RUM_ENABLE_PRIVACY_FOR_ACTION_NAME', True)
+        ),
+    }
+
+
 def common(_request):
+    datadog_rum_config = _datadog_rum_config()
+
     return {
         'support_email': settings.SUPPORT_EMAIL,
         'full_application_name': settings.FULL_APPLICATION_NAME,
         'platform_name': settings.PLATFORM_NAME,
         'application_name': settings.APPLICATION_NAME,
         'footer_links': settings.FOOTER_LINKS,
+        'datadog_rum_config': datadog_rum_config,
+        'datadog_rum_config_json': json.dumps(datadog_rum_config),
     }

--- a/analytics_dashboard/core/tests/test_context_processors.py
+++ b/analytics_dashboard/core/tests/test_context_processors.py
@@ -1,0 +1,65 @@
+import json
+
+from django.test import SimpleTestCase
+from django.test.utils import override_settings
+
+from analytics_dashboard.core.context_processors import common
+
+
+class DatadogRumContextProcessorTests(SimpleTestCase):
+    def get_datadog_rum_config(self):
+        return common(None)['datadog_rum_config']
+
+    def test_datadog_rum_disabled_by_default(self):
+        config = self.get_datadog_rum_config()
+
+        self.assertFalse(config['enabled'])
+
+    @override_settings(
+        DATADOG_RUM_ENABLED=True,
+        DATADOG_RUM_APPLICATION_ID='test-application-id',
+        DATADOG_RUM_CLIENT_TOKEN=None,
+    )
+    def test_datadog_rum_requires_credentials(self):
+        config = self.get_datadog_rum_config()
+
+        self.assertFalse(config['enabled'])
+
+    @override_settings(
+        DATADOG_RUM_ENABLED=True,
+        DATADOG_RUM_APPLICATION_ID='test-application-id',
+        DATADOG_RUM_CLIENT_TOKEN='test-client-token',
+        DATADOG_RUM_ENV='stg',
+        DATADOG_RUM_SESSION_SAMPLE_RATE='20',
+        DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE='0',
+    )
+    def test_datadog_rum_enabled_with_required_config(self):
+        config = self.get_datadog_rum_config()
+
+        self.assertTrue(config['enabled'])
+        self.assertEqual(config['applicationId'], 'test-application-id')
+        self.assertEqual(config['clientToken'], 'test-client-token')
+        self.assertEqual(config['env'], 'stg')
+        self.assertEqual(config['service'], 'edx-insights-frontend')
+        self.assertEqual(config['sessionSampleRate'], 20)
+        self.assertEqual(config['sessionReplaySampleRate'], 0)
+
+    @override_settings(
+        DATADOG_RUM_ENABLED='false',
+        DATADOG_RUM_APPLICATION_ID='test-application-id',
+        DATADOG_RUM_CLIENT_TOKEN='test-client-token',
+    )
+    def test_datadog_rum_string_false_is_disabled(self):
+        config = self.get_datadog_rum_config()
+
+        self.assertFalse(config['enabled'])
+
+    @override_settings(
+        DATADOG_RUM_ENABLED=True,
+        DATADOG_RUM_APPLICATION_ID='test-application-id',
+        DATADOG_RUM_CLIENT_TOKEN='test-client-token',
+    )
+    def test_datadog_rum_json_matches_config(self):
+        context = common(None)
+
+        self.assertEqual(json.loads(context['datadog_rum_config_json']), context['datadog_rum_config'])

--- a/analytics_dashboard/core/tests/test_context_processors.py
+++ b/analytics_dashboard/core/tests/test_context_processors.py
@@ -45,6 +45,19 @@ class DatadogRumContextProcessorTests(SimpleTestCase):
         self.assertEqual(config['sessionReplaySampleRate'], 0)
 
     @override_settings(
+        DATADOG_RUM_ENABLED=True,
+        DATADOG_RUM_APPLICATION_ID='test-application-id',
+        DATADOG_RUM_CLIENT_TOKEN='test-client-token',
+        DATADOG_RUM_SESSION_SAMPLE_RATE='invalid',
+        DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE=None,
+    )
+    def test_datadog_rum_invalid_sample_rates_use_defaults(self):
+        config = self.get_datadog_rum_config()
+
+        self.assertEqual(config['sessionSampleRate'], 20)
+        self.assertEqual(config['sessionReplaySampleRate'], 0)
+
+    @override_settings(
         DATADOG_RUM_ENABLED='false',
         DATADOG_RUM_APPLICATION_ID='test-application-id',
         DATADOG_RUM_CLIENT_TOKEN='test-client-token',

--- a/analytics_dashboard/settings/base.py
+++ b/analytics_dashboard/settings/base.py
@@ -292,6 +292,22 @@ SEGMENT_IO_KEY = 'YOUR_KEY'
 SEGMENT_IGNORE_EMAIL_REGEX = None
 ########## END SEGMENT.IO
 
+########## DATADOG RUM
+# Browser RUM is disabled by default and requires deployment-provided public credentials.
+DATADOG_RUM_ENABLED = False
+DATADOG_RUM_APPLICATION_ID = None
+DATADOG_RUM_CLIENT_TOKEN = None
+DATADOG_RUM_SITE = 'datadoghq.com'
+DATADOG_RUM_SERVICE = 'edx-insights-frontend'
+DATADOG_RUM_ENV = None
+DATADOG_RUM_VERSION = '1.0.0'
+DATADOG_RUM_SCRIPT_URL = 'https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum.js'
+DATADOG_RUM_SESSION_SAMPLE_RATE = 20
+DATADOG_RUM_SESSION_REPLAY_SAMPLE_RATE = 0
+DATADOG_RUM_DEFAULT_PRIVACY_LEVEL = 'mask'
+DATADOG_RUM_ENABLE_PRIVACY_FOR_ACTION_NAME = True
+########## END DATADOG RUM
+
 ########## SUPPORT -- Ths value should be overridden for production deployments.
 SUPPORT_EMAIL = 'support@example.com'
 HELP_URL = 'http://127.0.0.1/en/latest'

--- a/analytics_dashboard/static/js/application-main.js
+++ b/analytics_dashboard/static/js/application-main.js
@@ -10,6 +10,12 @@ require('bootstrap-accessibility-plugin/plugins/js/bootstrap-accessibility');
 // eslint-disable-next-line import/no-dynamic-require
 require(process.env.THEME_SCSS);
 
+require(['load/init-datadog-rum'], (DatadogRum) => {
+  'use strict';
+
+  DatadogRum.initDatadogRum();
+});
+
 require(['views/announcement-view'], AnnouncementView => {
   'use strict';
 

--- a/analytics_dashboard/static/js/load/init-datadog-rum.js
+++ b/analytics_dashboard/static/js/load/init-datadog-rum.js
@@ -1,0 +1,80 @@
+/**
+ * Initializes Datadog RUM from dashboard template configuration.
+ */
+define(['utils/datadog-rum'], (DatadogRumUtils) => {
+  'use strict';
+
+  const CONFIG_ELEMENT_ID = 'datadog-rum-config';
+  let initialized = false;
+
+  const readRumConfig = () => {
+    const configElement = document.getElementById(CONFIG_ELEMENT_ID);
+    if (!configElement) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(configElement.textContent || configElement.innerText);
+    } catch (error) {
+      return null;
+    }
+  };
+
+  const hasRequiredConfig = config => (
+    config && config.enabled && config.applicationId && config.clientToken
+  );
+
+  const initRum = (config, datadogRum) => {
+    datadogRum.init({
+      applicationId: config.applicationId,
+      clientToken: config.clientToken,
+      site: config.site,
+      service: config.service,
+      env: config.env,
+      version: config.version,
+      sessionSampleRate: config.sessionSampleRate,
+      sessionReplaySampleRate: config.sessionReplaySampleRate,
+      trackUserInteractions: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: config.defaultPrivacyLevel,
+      enablePrivacyForActionName: config.enablePrivacyForActionName,
+      beforeSend: DatadogRumUtils.beforeSend,
+    });
+  };
+
+  const initDatadogRum = (config = readRumConfig(), datadogRum = window.DD_RUM) => {
+    if (initialized || !hasRequiredConfig(config) || !datadogRum || !datadogRum.init) {
+      return false;
+    }
+
+    initialized = true;
+    if (datadogRum.onReady) {
+      datadogRum.onReady(() => initRum(config, datadogRum));
+    } else {
+      initRum(config, datadogRum);
+    }
+
+    return true;
+  };
+
+  const setContext = (models, datadogRum = window.DD_RUM) => {
+    if (!datadogRum || !datadogRum.setGlobalContextProperty) {
+      return;
+    }
+
+    const context = DatadogRumUtils.buildRumContext(models);
+    Object.keys(context).forEach((key) => {
+      datadogRum.setGlobalContextProperty(key, context[key]);
+    });
+  };
+
+  return {
+    initDatadogRum,
+    readRumConfig,
+    setContext,
+    _resetForTests: () => {
+      initialized = false;
+    },
+  };
+});

--- a/analytics_dashboard/static/js/load/init-datadog-rum.js
+++ b/analytics_dashboard/static/js/load/init-datadog-rum.js
@@ -73,7 +73,7 @@ define(['utils/datadog-rum'], (DatadogRumUtils) => {
     initDatadogRum,
     readRumConfig,
     setContext,
-    _resetForTests: () => {
+    resetForTests: () => {
       initialized = false;
     },
   };

--- a/analytics_dashboard/static/js/load/init-page.js
+++ b/analytics_dashboard/static/js/load/init-page.js
@@ -4,12 +4,17 @@
 const initTracking = require('load/init-tracking');
 
 define([
-  'jquery', 'load/init-models', 'load/init-tooltips',
-], ($, models) => {
+  'jquery', 'load/init-models', 'load/init-datadog-rum', 'load/init-tooltips',
+], ($, models, DatadogRum) => {
   'use strict';
 
   // initialize tracking
   initTracking(models);
+
+  DatadogRum.setContext(models);
+  models.trackingModel.on('change:page', () => {
+    DatadogRum.setContext(models);
+  });
 
   return {
     models,

--- a/analytics_dashboard/static/js/test/specs/datadog-rum-spec.js
+++ b/analytics_dashboard/static/js/test/specs/datadog-rum-spec.js
@@ -1,0 +1,73 @@
+define(['models/course-model', 'models/tracking-model', 'utils/datadog-rum'], (
+  CourseModel,
+  TrackingModel,
+  DatadogRumUtils,
+) => {
+  'use strict';
+
+  describe('Datadog RUM utils', () => {
+    it('redacts sensitive strings', () => {
+      const url = 'https://insights.edx.org/u/edxavier?email=edx@example.com&text_search=learner@example.com';
+
+      expect(DatadogRumUtils.sanitizeString(url)).toEqual(
+        'https://insights.edx.org/u/[REDACTED]?email=[REDACTED]&text_search=[REDACTED]',
+      );
+    });
+
+    it('redacts sensitive RUM event fields', () => {
+      const event = {
+        view: {
+          url: 'https://insights.edx.org/courses/?email=edx@example.com',
+          name: 'Course list for edx@example.com',
+          referrer: 'https://profile.edx.org/u/edxavier',
+        },
+        resource: {
+          url: 'https://insights.edx.org/api/user/v1/accounts/edxavier',
+        },
+        action: {
+          target: {
+            name: 'Search learner edx@example.com',
+          },
+        },
+        error: {
+          resource: {
+            url: 'https://insights.edx.org/courses/?username=edxavier',
+          },
+        },
+      };
+
+      expect(DatadogRumUtils.beforeSend(event)).toBe(true);
+      expect(event.view.url).toEqual('https://insights.edx.org/courses/?email=[REDACTED]');
+      expect(event.view.name).toEqual('Course list for [REDACTED]');
+      expect(event.view.referrer).toEqual('https://profile.edx.org/u/[REDACTED]');
+      expect(event.resource.url).toEqual('https://insights.edx.org/api/user/v1/accounts/[REDACTED]');
+      expect(event.action.target.name).toEqual('Search learner [REDACTED]');
+      expect(event.error.resource.url).toEqual('https://insights.edx.org/courses/?username=[REDACTED]');
+    });
+
+    it('builds safe page and course context', () => {
+      const courseModel = new CourseModel({
+        courseId: 'course-v1:edX+DemoX+Demo_Course',
+        org: 'edX',
+      });
+      const trackingModel = new TrackingModel({
+        page: {
+          scope: 'course',
+          lens: 'enrollment',
+          report: 'activity',
+          depth: '',
+          name: 'course_enrollment_activity',
+        },
+      });
+
+      expect(DatadogRumUtils.buildRumContext({ courseModel, trackingModel })).toEqual({
+        'insights.page_name': 'course_enrollment_activity',
+        'insights.page_scope': 'course',
+        'insights.page_lens': 'enrollment',
+        'insights.page_report': 'activity',
+        'insights.course_id': 'course-v1:edX+DemoX+Demo_Course',
+        'insights.org': 'edX',
+      });
+    });
+  });
+});

--- a/analytics_dashboard/static/js/test/specs/init-datadog-rum-spec.js
+++ b/analytics_dashboard/static/js/test/specs/init-datadog-rum-spec.js
@@ -40,7 +40,7 @@ define(['load/init-datadog-rum'], (DatadogRum) => {
     });
 
     beforeEach(() => {
-      DatadogRum._resetForTests();
+      DatadogRum.resetForTests();
       removeConfigElement();
     });
 

--- a/analytics_dashboard/static/js/test/specs/init-datadog-rum-spec.js
+++ b/analytics_dashboard/static/js/test/specs/init-datadog-rum-spec.js
@@ -1,0 +1,128 @@
+define(['load/init-datadog-rum'], (DatadogRum) => {
+  'use strict';
+
+  describe('initDatadogRum', () => {
+    const config = {
+      enabled: true,
+      applicationId: 'test-application-id',
+      clientToken: 'test-client-token',
+      site: 'datadoghq.com',
+      service: 'edx-insights-frontend',
+      env: 'stg',
+      version: 'test-version',
+      sessionSampleRate: 20,
+      sessionReplaySampleRate: 0,
+      defaultPrivacyLevel: 'mask',
+      enablePrivacyForActionName: true,
+    };
+    let configElement;
+
+    const removeConfigElement = () => {
+      if (configElement && configElement.parentNode) {
+        configElement.parentNode.removeChild(configElement);
+      }
+      configElement = null;
+    };
+
+    const addConfigElement = (value) => {
+      removeConfigElement();
+      configElement = document.createElement('script');
+      configElement.id = 'datadog-rum-config';
+      configElement.type = 'application/json';
+      configElement.textContent = value;
+      document.body.appendChild(configElement);
+    };
+
+    const createDatadogRum = () => ({
+      init: jasmine.createSpy('init'),
+      onReady: jasmine.createSpy('onReady').and.callFake(callback => callback()),
+      setGlobalContextProperty: jasmine.createSpy('setGlobalContextProperty'),
+    });
+
+    beforeEach(() => {
+      DatadogRum._resetForTests();
+      removeConfigElement();
+    });
+
+    afterEach(() => {
+      removeConfigElement();
+    });
+
+    it('returns null when the template config is missing', () => {
+      expect(DatadogRum.readRumConfig()).toBe(null);
+    });
+
+    it('parses template config JSON', () => {
+      addConfigElement(JSON.stringify(config));
+
+      expect(DatadogRum.readRumConfig()).toEqual(config);
+    });
+
+    it('does not initialize when disabled', () => {
+      const datadogRum = createDatadogRum();
+
+      expect(DatadogRum.initDatadogRum({ ...config, enabled: false }, datadogRum)).toBe(false);
+      expect(datadogRum.onReady).not.toHaveBeenCalled();
+      expect(datadogRum.init).not.toHaveBeenCalled();
+    });
+
+    it('does not initialize when DD_RUM is missing', () => {
+      expect(DatadogRum.initDatadogRum(config, null)).toBe(false);
+    });
+
+    it('initializes RUM once with safe options', () => {
+      const datadogRum = createDatadogRum();
+
+      expect(DatadogRum.initDatadogRum(config, datadogRum)).toBe(true);
+      expect(DatadogRum.initDatadogRum(config, datadogRum)).toBe(false);
+      expect(datadogRum.onReady.calls.count()).toBe(1);
+      expect(datadogRum.init.calls.count()).toBe(1);
+
+      const options = datadogRum.init.calls.argsFor(0)[0];
+      expect(options.applicationId).toEqual(config.applicationId);
+      expect(options.clientToken).toEqual(config.clientToken);
+      expect(options.service).toEqual('edx-insights-frontend');
+      expect(options.env).toEqual('stg');
+      expect(options.sessionReplaySampleRate).toBe(0);
+      expect(options.trackUserInteractions).toBe(true);
+      expect(options.trackResources).toBe(true);
+      expect(options.trackLongTasks).toBe(true);
+      expect(options.beforeSend).toEqual(jasmine.any(Function));
+      expect(options.allowedTracingUrls).toBeUndefined();
+    });
+
+    it('sets safe global context', () => {
+      const datadogRum = createDatadogRum();
+      const models = {
+        courseModel: {
+          get: key => ({
+            courseId: 'course-v1:edX+DemoX+Demo_Course',
+            org: 'edX',
+          }[key]),
+        },
+        trackingModel: {
+          get: key => ({
+            page: {
+              scope: 'course',
+              lens: 'performance',
+              report: 'graded_content',
+              depth: '',
+              name: 'course_performance_graded_content',
+            },
+          }[key]),
+        },
+      };
+
+      DatadogRum.setContext(models, datadogRum);
+
+      expect(datadogRum.setGlobalContextProperty).toHaveBeenCalledWith(
+        'insights.page_name',
+        'course_performance_graded_content',
+      );
+      expect(datadogRum.setGlobalContextProperty).toHaveBeenCalledWith(
+        'insights.course_id',
+        'course-v1:edX+DemoX+Demo_Course',
+      );
+    });
+  });
+});

--- a/analytics_dashboard/static/js/utils/datadog-rum.js
+++ b/analytics_dashboard/static/js/utils/datadog-rum.js
@@ -1,0 +1,95 @@
+define([], () => {
+  'use strict';
+
+  const REDACTED = '[REDACTED]';
+  const EMAIL_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi;
+  const SENSITIVE_QUERY_PARAMS = [
+    'account',
+    'email',
+    'learner',
+    'name',
+    'search',
+    'text_search',
+    'user',
+    'user_id',
+    'userTrackingID',
+    'username',
+  ];
+
+  const replaceSensitiveQueryParam = (value, paramName) => {
+    const pattern = new RegExp(`([?&]${paramName}=)[^&#]*`, 'gi');
+    return value.replace(pattern, `$1${REDACTED}`);
+  };
+
+  const sanitizeString = (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    let sanitized = value
+      .replace(EMAIL_PATTERN, REDACTED)
+      .replace(/\/u\/[^/?&#]+/gi, `/u/${REDACTED}`)
+      .replace(/\/accounts\/[^/?&#]+/gi, `/accounts/${REDACTED}`);
+
+    SENSITIVE_QUERY_PARAMS.forEach((paramName) => {
+      sanitized = replaceSensitiveQueryParam(sanitized, paramName);
+    });
+
+    return sanitized;
+  };
+
+  const sanitizeField = (object, fieldName) => {
+    if (object && object[fieldName]) {
+      object[fieldName] = sanitizeString(object[fieldName]);
+    }
+  };
+
+  const beforeSend = (event) => {
+    if (!event) {
+      return true;
+    }
+
+    sanitizeField(event.view, 'url');
+    sanitizeField(event.view, 'name');
+    sanitizeField(event.view, 'referrer');
+    sanitizeField(event.resource, 'url');
+    sanitizeField(event.action && event.action.target, 'name');
+    sanitizeField(event.error && event.error.resource, 'url');
+
+    return true;
+  };
+
+  const modelValue = (model, key) => {
+    if (!model || typeof model.get !== 'function') {
+      return undefined;
+    }
+    return model.get(key);
+  };
+
+  const setIfPresent = (context, key, value) => {
+    if (value !== undefined && value !== null && value !== '') {
+      context[key] = value;
+    }
+  };
+
+  const buildRumContext = (models) => {
+    const context = {};
+    const page = modelValue(models && models.trackingModel, 'page') || {};
+
+    setIfPresent(context, 'insights.page_name', page.name);
+    setIfPresent(context, 'insights.page_scope', page.scope);
+    setIfPresent(context, 'insights.page_lens', page.lens);
+    setIfPresent(context, 'insights.page_report', page.report);
+    setIfPresent(context, 'insights.page_depth', page.depth);
+    setIfPresent(context, 'insights.course_id', modelValue(models && models.courseModel, 'courseId'));
+    setIfPresent(context, 'insights.org', modelValue(models && models.courseModel, 'org'));
+
+    return context;
+  };
+
+  return {
+    beforeSend,
+    buildRumContext,
+    sanitizeString,
+  };
+});

--- a/analytics_dashboard/static/js/utils/datadog-rum.js
+++ b/analytics_dashboard/static/js/utils/datadog-rum.js
@@ -40,7 +40,7 @@ define([], () => {
 
   const sanitizeField = (object, fieldName) => {
     if (object && object[fieldName]) {
-      object[fieldName] = sanitizeString(object[fieldName]);
+      object[fieldName] = sanitizeString(object[fieldName]); // eslint-disable-line no-param-reassign
     }
   };
 

--- a/analytics_dashboard/templates/base_dashboard.html
+++ b/analytics_dashboard/templates/base_dashboard.html
@@ -70,6 +70,11 @@
       </script>
     {% endif %}
 
+    {% if datadog_rum_config.enabled %}
+      <script id="datadog-rum-config" type="application/json">{{ datadog_rum_config_json|safe }}</script>
+      <script type="text/javascript" src="{{ datadog_rum_config.scriptUrl }}"></script>
+    {% endif %}
+
     <div id="footer-sock-push"></div>
   </div>
   {% block footer %}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = true
 DJANGO_SETTINGS_MODULE = analytics_dashboard.settings.test
 
 [testenv]
-passenv = 
+passenv =
     API_SERVER_URL
     API_AUTH_TOKEN
     LMS_HOSTNAME
@@ -20,26 +20,26 @@ passenv =
     COVERAGE_DIR
     DISPLAY
     SELENIUM_BROWSER
-deps = 
-    setuptools
+deps =
+    setuptools==68.2.2
     django42: -r requirements/django.txt
     -r {toxinidir}/requirements/test.txt
-allowlist_externals = 
+allowlist_externals =
     make
-commands = 
+commands =
     {posargs:pytest}
 
 [testenv:docs]
-deps = 
+deps =
     setuptools
     -r{toxinidir}/requirements/doc.txt
-allowlist_externals = 
+allowlist_externals =
     make
     env
-setenv = 
+setenv =
 # -W will treat warnings as errors.
     SPHINXOPTS = -W
-commands = 
+commands =
 # -e allows for overriding setting from the environment.
 # -C changes the directory to `docs` before running the command.
     make -e -C docs/en_us/dashboard clean


### PR DESCRIPTION
## Summary

Adds frontend-only Datadog RUM support for the Insights dashboard.

This change keeps RUM disabled by default until deployment config provides the Datadog application ID/client token. It initializes RUM only from the dashboard shell, adds safe Insights page/course context, and redacts sensitive values before events are sent.

## Changes

- Add `DATADOG_RUM_*` settings defaults.
- Expose safe RUM config through the common context processor.
- Render dashboard-only RUM config and browser SDK script in `base_dashboard.html`.
- Add guarded Datadog RUM bootstrap.
- Add safe page/course context updates.
- Add redaction for sensitive URLs/action names.
- Add focused config, bootstrap, redaction, and context tests.